### PR TITLE
Enable Spanish default and bilingual site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,4 +26,4 @@ markdown: kramdown
 permalink: pretty
 
 # The first language is the default language of your site
-language: ['en','es']
+languages: ['es','en']

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1,0 +1,44 @@
+nav:
+  services: "Services"
+  portfolio: "Portfolio"
+  about: "About"
+  contact: "Contact"
+header:
+  welcome: "Welcome to JR Consulting"
+  subtitle: "Professional Solutions"
+  button: "Our Services"
+about:
+  title: "About Me"
+  subtitle: "My professional experience."
+services:
+  title: "Services"
+  subtitle: "Consulting and development solutions."
+  mobile:
+    title: "Mobile Applications"
+    text: "App development for Android and iOS"
+  support:
+    title: "Systems Support"
+    text: "Maintenance of computers and networks"
+  web:
+    title: "Web Development"
+    text: "Corporate sites and custom applications"
+  process:
+    title: "Process Automation"
+    text: "Custom programs and workflow optimization"
+  sap:
+    title: "SAP ABAP Consulting"
+    text: "Expert in Netweaver ABAP/4 and MM VIM solutions"
+portfolio:
+  title: "Portfolio"
+  subtitle: "All my works."
+contact:
+  title: "Contact"
+  subtitle: "Get in touch through my networks:"
+  close: "Close"
+  client: "Client:"
+  date: "Date:"
+  service: "Service:"
+posts:
+  title: "Posts"
+  subscribe: "subscribe"
+  via_rss: "via RSS"

--- a/_i18n/es.yml
+++ b/_i18n/es.yml
@@ -1,0 +1,44 @@
+nav:
+  services: "Servicios"
+  portfolio: "Portafolio"
+  about: "Sobre mí"
+  contact: "Contacto"
+header:
+  welcome: "Bienvenido a JR Consulting"
+  subtitle: "Soluciones Profesionales"
+  button: "Nuestros Servicios"
+about:
+  title: "Sobre mí"
+  subtitle: "Mi experiencia profesional."
+services:
+  title: "Servicios"
+  subtitle: "Soluciones de consultoría y desarrollo."
+  mobile:
+    title: "Aplicaciones Móviles"
+    text: "Desarrollo de apps para Android e iOS"
+  support:
+    title: "Soporte de Sistemas"
+    text: "Mantenimiento de equipos y redes"
+  web:
+    title: "Desarrollo Web"
+    text: "Sitios corporativos y aplicaciones a medida"
+  process:
+    title: "Automatización de Procesos"
+    text: "Programas a medida y optimización de flujos de trabajo"
+  sap:
+    title: "Consultoría SAP ABAP"
+    text: "Especialista en Netweaver ABAP/4 y soluciones MM VIM"
+portfolio:
+  title: "Portafolio"
+  subtitle: "Todo mi trabajo."
+contact:
+  title: "Contacto"
+  subtitle: "Póngase en contacto a través de mis redes:"
+  close: "Cerrar"
+  client: "Cliente:"
+  date: "Fecha:"
+  service: "Servicio:"
+posts:
+  title: "Publicaciones"
+  subscribe: "suscribirse"
+  via_rss: "vía RSS"

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -3,8 +3,8 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Sobre mí</h2>
-                    <h3 class="section-subheading text-muted">Mi experiencia profesional.</h3>
+                    <h2 class="section-heading">{% t about.title %}</h2>
+                    <h3 class="section-subheading text-muted">{% t about.subtitle %}</h3>
                 </div>
             </div>
             <div class="row">

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -3,8 +3,8 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Contacto</h2>
-                    <h3 class="section-subheading text-muted">Póngase en contacto a través de mis redes:</h3>
+                    <h2 class="section-heading">{% t contact.title %}</h2>
+                    <h3 class="section-subheading text-muted">{% t contact.subtitle %}</h3>
                 </div>
             </div>
             <div class="row">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,16 +19,20 @@
                         <a href="#page-top"></a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#services">Servicios</a>
+                        <a class="page-scroll" href="#services">{% t nav.services %}</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#portfolio">Portafolio</a>
+                        <a class="page-scroll" href="#portfolio">{% t nav.portfolio %}</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#about">Sobre mí</a>
+                        <a class="page-scroll" href="#about">{% t nav.about %}</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#contact">Contacto</a>
+                        <a class="page-scroll" href="#contact">{% t nav.contact %}</a>
+                    </li>
+                    <li>
+                        <a href="{{ '/es/' | prepend: site.baseurl }}">ES</a> |
+                        <a href="{{ '/en/' | prepend: site.baseurl }}">EN</a>
                     </li>
                 </ul>
             </div>
@@ -41,9 +45,9 @@
     <header>
         <div class="container">
             <div class="intro-text">
-                <div class="intro-lead-in">Bienvenido a JR Consulting</div>
-                <div class="intro-heading">Soluciones Profesionales</div>
-                <a href="#services" class="page-scroll btn btn-xl">Nuestros Servicios</a>
+                <div class="intro-lead-in">{% t header.welcome %}</div>
+                <div class="intro-heading">{% t header.subtitle %}</div>
+                <a href="#services" class="page-scroll btn btn-xl">{% t header.button %}</a>
             </div>
         </div>
     </header>

--- a/_includes/modals.html
+++ b/_includes/modals.html
@@ -17,21 +17,21 @@
                             <img src="img/portfolio/{{ post.img }}" class="img-responsive img-centered" alt="{{ post.alt }}">
                             <p>{{ post.description }}</p>
                             <ul class="list-inline item-details">
-                                <li>Client:
+                                <li>{% t contact.client %}
                                     <strong><a href="http://movingoncourses.com">{{ post.client }}</a>
                                     </strong>
                                 </li>
-                                <li>Date:
+                                <li>{% t contact.date %}
                                 <!-- <strong><a href="http://startbootstrap.com">{{ post.project-date }}</a> -->
                                     <strong><a>{{ post.project-date }}</a>
                                     </strong>
                                 </li>
-                                <li>Service:
+                                <li>{% t contact.service %}
                                     <strong><a>{{ post.category }}</a>
                                     </strong>
                                 </li>
                             </ul>
-                            <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> Close</button>
+                            <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> {% t contact.close %}</button>
                         </div>
                     </div>
                 </div>

--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -3,8 +3,8 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Portfolio</h2>
-                    <h3 class="section-subheading text-muted">All my works.</h3>
+                    <h2 class="section-heading">{% t portfolio.title %}</h2>
+                    <h3 class="section-subheading text-muted">{% t portfolio.subtitle %}</h3>
                 </div>
             </div>
             <div class="row">

--- a/_includes/services.html
+++ b/_includes/services.html
@@ -3,8 +3,8 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Servicios</h2>
-                    <h3 class="section-subheading text-muted">Soluciones de consultoría y desarrollo.</h3>
+                    <h2 class="section-heading">{% t services.title %}</h2>
+                    <h3 class="section-subheading text-muted">{% t services.subtitle %}</h3>
                 </div>
             </div>
             <div class="row text-center">
@@ -13,39 +13,39 @@
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-android fa-stack-1x fa-inverse"></i>
                     </span>
-                    <h4 class="service-heading">Aplicaciones Móviles</h4>
-                    <p class="text-muted">Desarrollo de apps para Android e iOS</p>
+                    <h4 class="service-heading">{% t services.mobile.title %}</h4>
+                    <p class="text-muted">{% t services.mobile.text %}</p>
                 </div>
                 <div class="col-md-6">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-laptop fa-stack-1x fa-inverse"></i>
                     </span>
-                    <h4 class="service-heading">Soporte de Sistemas</h4>
-                    <p class="text-muted">Mantenimiento de equipos y redes</p>
+                    <h4 class="service-heading">{% t services.support.title %}</h4>
+                    <p class="text-muted">{% t services.support.text %}</p>
                 </div>
                 <div class="col-md-6">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-globe fa-stack-1x fa-inverse"></i>
                     </span>
-                    <h4 class="service-heading">Desarrollo Web</h4>
-                    <p class="text-muted">Sitios corporativos y aplicaciones a medida</p>
+                    <h4 class="service-heading">{% t services.web.title %}</h4>
+                    <p class="text-muted">{% t services.web.text %}</p>
                 </div>
                 <div class="col-md-6">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-keyboard-o fa-stack-1x fa-inverse"></i>
                     </span>
-                    <h4 class="service-heading">Automatización de Procesos</h4>
-                    <p class="text-muted">Programas a medida y optimización de flujos de trabajo</p>
+                    <h4 class="service-heading">{% t services.process.title %}</h4>
+                    <p class="text-muted">{% t services.process.text %}</p>
                 </div>
                      <div class="">
                          <span class="fa-stack fa-4x">
                     <img class="img-responsive" src="img/about/sap.png" alt="">
                                   </span>
-                    <h4 class="service-heading">Consultoría SAP ABAP</h4>
-                    <p class="text-muted">Especialista en Netweaver ABAP/4 y soluciones MM VIM</p>
+                    <h4 class="service-heading">{% t services.sap.title %}</h4>
+                    <p class="text-muted">{% t services.sap.text %}</p>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <div class="home">
 
-  <h1>Posts</h1>
+  <h1>{% t posts.title %}</h1>
 
   <ul class="posts">
     {% for post in site.posts %}
@@ -14,6 +14,6 @@ layout: default
     {% endfor %}
   </ul>
 
-  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
+  <p class="rss-subscribe">{% t posts.subscribe %} <a href="{{ "/feed.xml" | prepend: site.baseurl }}">{% t posts.via_rss %}</a></p>
 
 </div>


### PR DESCRIPTION
## Summary
- configure languages with Spanish as default
- add i18n translation files for English and Spanish
- update templates to use translation tags
- add language selector in navigation

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e7648a1483249577051e6f0bf79f