### PR TITLE
Center timeline photos within circles

### DIFF
--- a/_includes/css/agency.css
+++ b/_includes/css/agency.css
@@ -498,6 +498,14 @@ section h3.section-subheading {
     background-color: #{{ site.color.primary }};
 }
 
+/* Ensure images fill and are centered within the circular frame */
+.timeline>li .timeline-image img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
 .timeline>li .timeline-image h4 {
     margin-top: 12px;
     font-size: 10px;


### PR DESCRIPTION
## Summary
- ensure timeline images fill and remain centered in their circular frame

## Testing
- `ruby -v`

------
https://chatgpt.com/codex/tasks/task_e_6888ea90de5c8324b65e2731af738287