### PR TITLE
Fix broken EN navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -31,8 +31,7 @@
                         <a class="page-scroll" href="#contact">Contacto</a>
                     </li>
                     <li>
-                        <a href="{{ '/es/' | prepend: site.baseurl }}">ES</a> |
-                        <a href="{{ '/en/' | prepend: site.baseurl }}">EN</a>
+                        <a href="{{ '/' | prepend: site.baseurl }}">ES</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- remove link to non-existent English homepage

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888f07925488324a40cfc0cb3d6bb00