### PR TITLE
Add bilingual support and style updates

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -3,8 +3,8 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Sobre mí</h2>
-                    <h3 class="section-subheading text-muted">Mi experiencia profesional.</h3>
+                    <h2 class="section-heading">{% t about.title %}</h2>
+                    <h3 class="section-subheading text-muted">{% t about.subtitle %}</h3>
                 </div>
             </div>
             <div class="row">

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -3,8 +3,8 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Contacto</h2>
-                    <h3 class="section-subheading text-muted">Póngase en contacto a través de mis redes:</h3>
+                    <h2 class="section-heading">{% t contact.title %}</h2>
+                    <h3 class="section-subheading text-muted">{% t contact.subtitle %}</h3>
                 </div>
             </div>
             <div class="row">

--- a/_includes/css/agency.css
+++ b/_includes/css/agency.css
@@ -173,6 +173,7 @@ fieldset[disabled] .btn-xl.active {
 .navbar-default {
     border-color: transparent;
     background-color: #222;
+    box-shadow: 0 2px 4px rgba(0,0,0,.3);
 }
 
 .navbar-default .navbar-brand {
@@ -266,7 +267,7 @@ header {
     text-align: center;
     color: #fff;
     background-attachment: scroll;
-    background-image: url(../img/header-bg-code.jpg);
+    background-image: linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)), url(../img/header-bg-code.jpg);
     background-position: center center;
     background-repeat: none;
     -webkit-background-size: cover;

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,19 +19,22 @@
                         <a href="#page-top"></a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#services">Servicios</a>
+                        <a class="page-scroll" href="#services">{% t nav.services %}</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#portfolio">Portafolio</a>
+                        <a class="page-scroll" href="#portfolio">{% t nav.portfolio %}</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#about">Sobre mí</a>
+                        <a class="page-scroll" href="#about">{% t nav.about %}</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#contact">Contacto</a>
+                        <a class="page-scroll" href="#contact">{% t nav.contact %}</a>
                     </li>
                     <li>
-                        <a href="{{ '/' | prepend: site.baseurl }}">ES</a>
+                        <a href="{{ page.url | remove_language | prepend: '/es' | prepend: site.baseurl }}">ES</a>
+                    </li>
+                    <li>
+                        <a href="{{ page.url | remove_language | prepend: '/en' | prepend: site.baseurl }}">EN</a>
                     </li>
                 </ul>
             </div>
@@ -44,9 +47,9 @@
     <header>
         <div class="container">
             <div class="intro-text">
-                <div class="intro-lead-in">Bienvenido a JR Consulting</div>
-                <div class="intro-heading">Soluciones Profesionales</div>
-                <a href="#services" class="page-scroll btn btn-xl">Nuestros Servicios</a>
+                <div class="intro-lead-in">{% t header.welcome %}</div>
+                <div class="intro-heading">{% t header.subtitle %}</div>
+                <a href="#services" class="page-scroll btn btn-xl">{% t header.button %}</a>
             </div>
         </div>
     </header>

--- a/_includes/modals.html
+++ b/_includes/modals.html
@@ -17,21 +17,21 @@
                             <img src="img/portfolio/{{ post.img }}" class="img-responsive img-centered" alt="{{ post.alt }}">
                             <p>{{ post.description }}</p>
                             <ul class="list-inline item-details">
-                                <li>Cliente:
+                                <li>{% t contact.client %}
                                     <strong><a href="http://movingoncourses.com">{{ post.client }}</a>
                                     </strong>
                                 </li>
-                                <li>Fecha:
+                                <li>{% t contact.date %}
                                 <!-- <strong><a href="http://startbootstrap.com">{{ post.project-date }}</a> -->
                                     <strong><a>{{ post.project-date }}</a>
                                     </strong>
                                 </li>
-                                <li>Servicio:
+                                <li>{% t contact.service %}
                                     <strong><a>{{ post.category }}</a>
                                     </strong>
                                 </li>
                             </ul>
-                            <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> Cerrar</button>
+                            <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> {% t contact.close %}</button>
                         </div>
                     </div>
                 </div>

--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -3,8 +3,8 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Portafolio</h2>
-                    <h3 class="section-subheading text-muted">Todo mi trabajo.</h3>
+                    <h2 class="section-heading">{% t portfolio.title %}</h2>
+                    <h3 class="section-subheading text-muted">{% t portfolio.subtitle %}</h3>
                 </div>
             </div>
             <div class="row">

--- a/_includes/services.html
+++ b/_includes/services.html
@@ -3,8 +3,8 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Servicios</h2>
-                    <h3 class="section-subheading text-muted">Soluciones de consultoría y desarrollo.</h3>
+                    <h2 class="section-heading">{% t services.title %}</h2>
+                    <h3 class="section-subheading text-muted">{% t services.subtitle %}</h3>
                 </div>
             </div>
             <div class="row text-center">
@@ -13,39 +13,39 @@
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-android fa-stack-1x fa-inverse"></i>
                     </span>
-                    <h4 class="service-heading">Aplicaciones Móviles</h4>
-                    <p class="text-muted">Desarrollo de apps para Android e iOS</p>
+                    <h4 class="service-heading">{% t services.mobile.title %}</h4>
+                    <p class="text-muted">{% t services.mobile.text %}</p>
                 </div>
                 <div class="col-md-6">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-laptop fa-stack-1x fa-inverse"></i>
                     </span>
-                    <h4 class="service-heading">Soporte de Sistemas</h4>
-                    <p class="text-muted">Mantenimiento de equipos y redes</p>
+                    <h4 class="service-heading">{% t services.support.title %}</h4>
+                    <p class="text-muted">{% t services.support.text %}</p>
                 </div>
                 <div class="col-md-6">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-globe fa-stack-1x fa-inverse"></i>
                     </span>
-                    <h4 class="service-heading">Desarrollo Web</h4>
-                    <p class="text-muted">Sitios corporativos y aplicaciones a medida</p>
+                    <h4 class="service-heading">{% t services.web.title %}</h4>
+                    <p class="text-muted">{% t services.web.text %}</p>
                 </div>
                 <div class="col-md-6">
                     <span class="fa-stack fa-4x">
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-keyboard-o fa-stack-1x fa-inverse"></i>
                     </span>
-                    <h4 class="service-heading">Automatización de Procesos</h4>
-                    <p class="text-muted">Programas a medida y optimización de flujos de trabajo</p>
+                    <h4 class="service-heading">{% t services.process.title %}</h4>
+                    <p class="text-muted">{% t services.process.text %}</p>
                 </div>
                      <div class="">
                          <span class="fa-stack fa-4x">
                     <img class="img-responsive" src="img/about/sap.png" alt="">
                                   </span>
-                    <h4 class="service-heading">Consultoría SAP ABAP</h4>
-                    <p class="text-muted">Especialista en Netweaver ABAP/4 y soluciones MM VIM</p>
+                    <h4 class="service-heading">{% t services.sap.title %}</h4>
+                    <p class="text-muted">{% t services.sap.text %}</p>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,10 @@
 ---
 layout: default
+language: es
 ---
 <div class="home">
 
-  <h1>Publicaciones</h1>
+  <h1>{% t posts.title %}</h1>
 
   <ul class="posts">
     {% for post in site.posts %}
@@ -14,6 +15,6 @@ layout: default
     {% endfor %}
   </ul>
 
-  <p class="rss-subscribe">suscribirse <a href="{{ "/feed.xml" | prepend: site.baseurl }}">vía RSS</a></p>
+  <p class="rss-subscribe">{% t posts.subscribe %} <a href="{{ "/feed.xml" | prepend: site.baseurl }}">{% t posts.via_rss %}</a></p>
 
 </div>


### PR DESCRIPTION
## Summary
- enable i18n strings on the home page and sections
- add language switcher links to the navigation bar
- tweak header and navbar styling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6888fc9290d08324b48861dbb4babb81